### PR TITLE
feat: use rustls-tls instead of native-tls for meshx_client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tokio = {workspace = true, features = ["full"]}
 tracing = {workspace = true, features = ["attributes"]}
 tracing-subscriber = {workspace = true, features = ["env-filter", "ansi", "time", "json"]}
 wash-runtime = {workspace = true, features = ["wasi-webgpu"]}
-meshx_client = { path = "./crates/meshx-client" }
+meshx_client = { path = "./crates/meshx-client", default-features = false, features = ["rustls-tls"] }
 
 [workspace.dependencies]
 anyhow = {version = "1.0.98", default-features = false}


### PR DESCRIPTION
## Summary

This PR switches the meshx_client dependency from using native-tls to rustls-tls for better portability and to avoid system TLS library dependencies.

## Changes

- Updated meshx_client dependency in Cargo.toml to use rustls-tls feature
- Disabled default features (which use native-tls)
- Explicitly enabled rustls-tls feature

## Benefits

- Better portability across different platforms
- No dependency on system OpenSSL/native TLS libraries
- Pure Rust TLS implementation
- Easier Docker builds without needing to install OpenSSL

## Files Changed

- Modified Cargo.toml to change meshx_client dependency configuration

## Test Plan

- Verify cargo build completes successfully
- Test that HTTPS requests still work correctly
- Verify Docker build succeeds